### PR TITLE
QA-17/restrict ability to resize window

### DIFF
--- a/QuotebookApp/App.xaml.cs
+++ b/QuotebookApp/App.xaml.cs
@@ -14,4 +14,20 @@ public partial class App : Application
 
 		MainPage = new AppShell();
 	}
+
+#if WINDOWS || MACCATALYST
+    protected override Window CreateWindow(IActivationState activationState)
+    {
+        Window window = base.CreateWindow(activationState);
+
+        window.MinimumHeight = 760;
+        window.MaximumHeight = 760;
+        window.Height = 760;
+        window.MinimumWidth = 1440;
+        window.MaximumWidth = 1440;
+        window.Width = 1440;
+
+        return window;
+    }
+#endif
 }


### PR DESCRIPTION
Prevented window from being resized on Windows and MacOS.

Closes #17 