### PR TITLE
QA-45/add notion of app admin and invisible user

### DIFF
--- a/QuotebookApp/Model/User.cs
+++ b/QuotebookApp/Model/User.cs
@@ -2,14 +2,23 @@
 
 public class User
 {
-    public User(int userID, string userName, string userPass)
+    public enum UserPermissionType
+    {
+        Admin = 0,
+        Normal,
+        Invisible,
+    }
+
+    public User(int userID, string userName, string userPass, UserPermissionType userType)
     {
         UserID = userID;
         UserName = userName;
         UserPass = userPass;
+        UserType = userType;
     }
 
     public int UserID { get; set; }
     public string UserName { get; set; }
     public string UserPass { get; set; }
+    public UserPermissionType UserType { get; set; }
 }

--- a/QuotebookApp/Services/UserService.cs
+++ b/QuotebookApp/Services/UserService.cs
@@ -20,13 +20,31 @@ public class UserService
     {
         ClearUsers();
 
-        string range = "Users!A2:C";
+        string range = "Users!A2:D";
 
         SheetData data = await service.GetResponse(range);
 
         foreach (string[] value in data.Values)
         {
-            User user = new User(Convert.ToInt32(value[0]), value[1], value[2]);
+            string type = value[3];
+            User.UserPermissionType permType;
+            switch (type)
+            {
+                case "A":
+                    permType = User.UserPermissionType.Admin;
+                    break;
+                case "N":
+                    permType = User.UserPermissionType.Normal;
+                    break;
+                case "I":
+                    permType = User.UserPermissionType.Invisible;
+                    break;
+                default:
+                    permType = User.UserPermissionType.Normal;
+                    break;
+            }
+
+            User user = new User(Convert.ToInt32(value[0]), value[1], value[2], permType);
             userList.Add(user);
         }
 

--- a/QuotebookApp/ViewModel/QuoteViewModel.cs
+++ b/QuotebookApp/ViewModel/QuoteViewModel.cs
@@ -90,7 +90,10 @@ public partial class QuoteViewModel : BaseViewModel
         this.quoteService = quoteService;
         foreach (User user in GlobalData.Users)
         {
-            Users.Add(user.UserName);
+            /* Don't add invisible users to pickers, point of an invisible
+             * user is that other app users do not see them, but they have access */
+            if (user.UserType != User.UserPermissionType.Invisible)
+                Users.Add(user.UserName);
         }
 
         FilterBtnText = "Filter";
@@ -194,6 +197,12 @@ public partial class QuoteViewModel : BaseViewModel
     {
         if (IsBusy)
             return;
+
+        if (GlobalData.CurrentUser.UserType == User.UserPermissionType.Invisible)
+        {
+            Shell.Current.DisplayAlert("Warning!", "Users with your permission level are not allowed to add quotes. Contact your app administrator.", "OK");
+            return;
+        }
 
         IsAddQuote = true;
     }


### PR DESCRIPTION
Added app administrators and invisible users. App admins don't have any extra permissions (yet), but invisible users do not pop up in any pickers (filter quotes, add quote, etc.) and they do not have the ability to add quotes.

Closes #45 