### PR TITLE
QA-50/allow editing and deletion of quotes

### DIFF
--- a/QuotebookApp/Services/BaseSheetService.cs
+++ b/QuotebookApp/Services/BaseSheetService.cs
@@ -148,7 +148,6 @@ public class BaseSheetService
 
         JsonContent json_content = JsonContent.Create<UploadValues>(vals);
         HttpContent content = (HttpContent)json_content;
-        Debug.WriteLine(content);
         var uri = new Uri(url);
 
         int retries = 0;

--- a/QuotebookApp/Services/BaseSheetService.cs
+++ b/QuotebookApp/Services/BaseSheetService.cs
@@ -8,6 +8,13 @@ namespace QuotebookApp.Services;
 
 class UploadValues
 {
+    public UploadValues(string range, string majorDimension, string[][] values)
+    {
+        this.range = range;
+        this.majorDimension = majorDimension;
+        this.values = values;
+    }
+
     public string range { get; set; }
     public string majorDimension { get; set; }
     public string[][] values { get; set; }
@@ -48,17 +55,6 @@ public class BaseSheetService
         }
     }
 
-    private UploadValues ConstructUploadObject(string range, string major_dimension, string[] value_array)
-    {
-        UploadValues vals = new UploadValues();
-        vals.range = range;
-        vals.majorDimension = major_dimension;
-        string[][] values = new string[value_array.Length][];
-        values[0] = value_array;
-        vals.values = values;
-        return vals;
-    }
-
 
     public async Task<SheetData> GetResponse(string range)
     {
@@ -93,7 +89,7 @@ public class BaseSheetService
         }
     }
 
-    public async Task SetResponse(string range, string[] value_array)
+    public async Task SetResponse(string range, string[][] value_array)
     {
         string base_url = GlobalData.BaseURL;
         string spreadsheet_id = GlobalData.SheetID;
@@ -103,7 +99,7 @@ public class BaseSheetService
 
         var url = $"{base_url}/{spreadsheet_id}/values/{range}:append?valueInputOption={value_input_option}&insertDataOption={insert_data_option}";
 
-        UploadValues vals = ConstructUploadObject(range, major_dimension, value_array);
+        UploadValues vals = new UploadValues(range, major_dimension, value_array);
 
         JsonContent json_content = JsonContent.Create<UploadValues>(vals);
         HttpContent content = (HttpContent)json_content;
@@ -139,7 +135,7 @@ public class BaseSheetService
         }
     }
 
-    public async Task EditResponse(string range, string[] value_array)
+    public async Task EditResponse(string range, string[][] value_array)
     {
         string base_url = GlobalData.BaseURL;
         string spreadsheet_id = GlobalData.SheetID;
@@ -148,10 +144,11 @@ public class BaseSheetService
 
         var url = $"{base_url}/{spreadsheet_id}/values/{range}?valueInputOption={value_input_option}";
 
-        UploadValues vals = ConstructUploadObject(range, major_dimension, value_array);
+        UploadValues vals = new UploadValues(range, major_dimension, value_array);
 
         JsonContent json_content = JsonContent.Create<UploadValues>(vals);
         HttpContent content = (HttpContent)json_content;
+        Debug.WriteLine(content);
         var uri = new Uri(url);
 
         int retries = 0;

--- a/QuotebookApp/Services/UserService.cs
+++ b/QuotebookApp/Services/UserService.cs
@@ -53,12 +53,13 @@ public class UserService
 
     public async Task SetUserPassword(string password)
     {
-        int user_id = GlobalData.CurrentUser.UserID;
-        int sheet_row = user_id + 1;
-        string range = $"Users!C{sheet_row}";
+        int user = GlobalData.Users.FindIndex(u => (u.UserID == GlobalData.CurrentUser.UserID));
+        string range = $"Users!C{user+2}";
 
         string[] values = { password };
+        string[][] values_send = new string[1][];
+        values_send[0] = values;
 
-        await service.EditResponse(range, values);
+        await service.EditResponse(range, values_send);
     }
 }

--- a/QuotebookApp/View/QuotePage.xaml
+++ b/QuotebookApp/View/QuotePage.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:model="clr-namespace:QuotebookApp.Model"
+             xmlns:viewmodel="clr-namespace:QuotebookApp.ViewModel"
              x:Class="QuotebookApp.View.QuotePage"
              Title="{Binding Title}">
     <VerticalStackLayout>
@@ -14,7 +15,7 @@
               RowDefinitions="Auto,Auto,Auto"
               Padding="10"
               RowSpacing="10"
-              IsVisible="{Binding IsNotAddQuote}">
+              IsVisible="{Binding IsNotChangeQuote}">
             <Button Text="{Binding FilterBtnText}"
                     HeightRequest="{Binding TopButtonHeight}"
                     Grid.Row="0"
@@ -44,12 +45,12 @@
                       ColumnSpacing="{Binding FilterFrameSpacing}">
                     <Picker ItemsSource="{Binding Users}"
                             Grid.Column="0"
-                            SelectedIndex="{Binding Quotee1Index}"
+                            SelectedIndex="{Binding FilterQuoteeIndex}"
                             Title="Said By"
                             HorizontalTextAlignment="Center"/>
                     <Picker ItemsSource="{Binding Users}"
                             Grid.Column="1"
-                            SelectedIndex="{Binding QuoterIndex}"
+                            SelectedIndex="{Binding FilterQuoterIndex}"
                             Title="Quoted By"/>
                     <DatePicker Date="{Binding QuoteDate}"
                                 Grid.Column="2"
@@ -72,6 +73,11 @@
                     <DataTemplate x:DataType="model:Quote">
                         <Frame Margin="5"
                                VerticalOptions="Fill">
+                            <Frame.GestureRecognizers>
+                                <TapGestureRecognizer NumberOfTapsRequired="2"
+                                                      CommandParameter="{Binding .}"
+                                                      Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodel:QuoteViewModel}}, Path=QuoteTappedCommand}"/>
+                            </Frame.GestureRecognizers>
                             <VerticalStackLayout Spacing="5">
                                 <Label FontSize="16"
                                            Text="{Binding QuoteString}"/>
@@ -88,11 +94,11 @@
             </CollectionView>
         </Grid>
         <Grid ColumnDefinitions="*,*"
-              RowDefinitions="*,150,*"
+              RowDefinitions="*,Auto,150,*"
               ColumnSpacing="7"
               RowSpacing="10"
               Padding="10"
-              IsVisible="{Binding IsAddQuote}"
+              IsVisible="{Binding IsChangeQuote}"
               VerticalOptions="Center">
             <Picker ItemsSource="{Binding Users}"
                     SelectedIndex="{Binding Quotee1Index}"
@@ -106,22 +112,53 @@
                     Grid.Row="0"
                     Grid.Column="1"
                     HorizontalOptions="StartAndExpand"/>
+            <Entry Placeholder="Said by"
+                   Text="{Binding Quotee1Other}"
+                   Grid.Row="1"
+                   Grid.Column="0"
+                   HorizontalOptions="EndAndExpand"
+                   WidthRequest="150"
+                   IsEnabled="{Binding Quotee1IsOther}"/>
+            <Entry Placeholder="And by"
+                   Text="{Binding Quotee2Other}"
+                   Grid.Row="1"
+                   Grid.Column="1"
+                   HorizontalOptions="StartAndExpand"
+                   WidthRequest="150"
+                   IsEnabled="{Binding Quotee2IsOther}"/>
             <Editor Placeholder="Quote"
                     Text="{Binding NewQuoteString}"
                     AutoSize="TextChanges"
                     HeightRequest="150"
-                    Grid.Row="1"
+                    Grid.Row="2"
                     Grid.ColumnSpan="2"/>
-            <Button Grid.Row="2"
-                    Grid.Column="0"
-                    Text="Back"
-                    IsEnabled="{Binding IsNotBusy}"
-                    Command="{Binding ExitAddQuoteCommand}"/>
-            <Button Grid.Row="2"
-                    Grid.Column="1"
-                    Text="Add Quote"
-                    IsEnabled="{Binding IsNotBusy}"
-                    Command="{Binding AddQuoteCommand}"/>
+            
+            <!-- This grid allows me to include the delete button only when editing a quote
+                 Otherwise, the delete button is not there. Needed this grid to provide enough
+                 columns and to hide the column with the delete button when a quote is being
+                 added normally -->
+            <Grid ColumnDefinitions="{Binding AddQuoteButtonsColumnDefinitions}"
+                  RowDefinitions="Auto"
+                  ColumnSpacing="10"
+                  Grid.Row="3"
+                  Grid.ColumnSpan="2">
+                <Button Grid.Row="0"
+                        Grid.Column="0"
+                        Text="Back"
+                        IsEnabled="{Binding IsNotBusy}"
+                        Command="{Binding ExitAddQuoteCommand}"/>
+                <Button Grid.Row="0"
+                        Grid.Column="1"
+                        Text="{Binding AddQuoteButtonText}"
+                        IsEnabled="{Binding IsNotBusy}"
+                        Command="{Binding UpdateQuoteCommand}" />
+                <Button Grid.Row="0"
+                        Grid.Column="2"
+                        Text="Delete"
+                        IsVisible="{Binding IsEditDeleteQuote}"
+                        IsEnabled="{Binding IsNotBusy}"
+                        Command="{Binding DeleteQuoteCommand}"/>
+            </Grid>
         </Grid>
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
I added the ability to edit and delete quotes. Along the way, I identified a bug with settings passwords (if the user IDs were not in order) and fixed it. In order to make the edit/delete quote feature feel complete, I had to add the ability to add a quotee or quoter who isn't a user in the app. In order to make my implementation of this work, I had to fix the known bug with the add quote 'said by' picker and filter 'said by' picker sharing the same data field. This closes an additional issue that was on the board. Lastly, I had to do some slight rework of the QuoteService. Note two issues were closed in this pull request!

Closes #50 
Closes #48 